### PR TITLE
Update queries.md

### DIFF
--- a/content/tutorials/clients/relay-vs-apollo/queries.md
+++ b/content/tutorials/clients/relay-vs-apollo/queries.md
@@ -236,7 +236,7 @@ With another GraphQL backend, your ids might only be unique per model. In this c
 ```js
 const client = new ApolloClient({
   networkInterface: createNetworkInterface({ uri: 'https://api.graph.cool/simple/v1/__PROJECT_ID__'}),
-  dataIdFromObject: o => o.__typename + o.id
+  dataIdFromObject: o => o.__typename + ' ' + o.id
 })
 ```
 


### PR DESCRIPTION
Make sure people don't introduce subtle bugs by using a flawed `dataIdFromObject` function that could produce ambiguous ids. Typenames in GraphQL can't contain spaces, so adding a space is safe enough.