### PR TITLE
Added a missing comma to a mutation query.

### DIFF
--- a/content/reference/api/simple-api/mutations/modifying-one-to-one-edges.md
+++ b/content/reference/api/simple-api/mutations/modifying-one-to-one-edges.md
@@ -77,7 +77,7 @@ disabled: true
 ---
 mutation {
   updatePost(
-    id: "cixnen24p33lo0143bexvr52n"
+    id: "cixnen24p33lo0143bexvr52n",
     metaInformationId: "cixnjj4l90ipl0106vp6u7a2f"
   ) {
     metaInformation {


### PR DESCRIPTION
It will cause a SyntaxError otherwise on the response.