### PR TITLE
Replaced clone with copy

### DIFF
--- a/content/reference/cli/commands/commands.md
+++ b/content/reference/cli/commands/commands.md
@@ -14,7 +14,7 @@ related:
 
 # Commands Overview
 
-The Graphcool CLI covers a wide range of use cases. As such, there are several commonly used commands. You can [create and clone new projects](!alias-aetoh3vad6), [synchronize changes](!alias-gechieb9ae) to your project file and other [miscellaneous commands](!alias-air0eiph9p).
+The Graphcool CLI covers a wide range of use cases. As such, there are several commonly used commands. You can [create and copy new projects](!alias-aetoh3vad6), [synchronize changes](!alias-gechieb9ae) to your project file and other [miscellaneous commands](!alias-air0eiph9p).
 
 ## More information
 

--- a/content/reference/cli/commands/creating-and-cloning-projects.md
+++ b/content/reference/cli/commands/creating-and-cloning-projects.md
@@ -12,7 +12,7 @@ related:
 
 # Creating and Cloning Projects
 
-You can use `graphcool init` to create and clone projects. This will create a new [`project.graphcool` file](!alias-ow2yei7mew) in the current folder.
+You can use `graphcool init` to create and copy projects. This will create a new [`project.graphcool` file](!alias-ow2yei7mew) in the current folder.
 
 ## General Settings
 
@@ -63,7 +63,7 @@ graphcool init --schema https://graphqlbin.com/instagram.graphql
 
 This creates a new `project.graphcool` file based on the passed schema file.
 
-### Cloning an existing project
+### Copying an existing project
 
 You can use `graphcool init --copy` to create a new project based on an existing one. The parameter `--copy-opts` can be used to specify what should be copied over: nothing, data, mutation-callbacks or both.
 

--- a/content/reference/cli/commands/creating-and-cloning-projects.md
+++ b/content/reference/cli/commands/creating-and-cloning-projects.md
@@ -1,6 +1,6 @@
 ---
 alias: aetoh3vad6
-path: /docs/reference/cli/commands/creating-and-cloning-projects
+path: /docs/reference/cli/commands/creating-and-copying-projects
 layout: REFERENCE
 description: The Graphcool CLI lets you work with the schema of a project. You can easily create a new project or update the schema of an existing one.
 tags:
@@ -10,7 +10,7 @@ related:
   more:
 ---
 
-# Creating and Cloning Projects
+# Creating and Copying Projects
 
 You can use `graphcool init` to create and copy projects. This will create a new [`project.graphcool` file](!alias-ow2yei7mew) in the current folder.
 

--- a/content/tutorials/general/graphcool-overview.md
+++ b/content/tutorials/general/graphcool-overview.md
@@ -96,7 +96,7 @@ Note that this also works for _local files_:
 graphcool init --schema ./instagram.graphl
 ```
 
-Sometimes it's helpful to copy (or _clone_) an existing project, this can be done using by passing the `--copy` option to `init`:
+Sometimes it's helpful to copy an existing project, this can be done using by passing the `--copy` option to `init`:
 
 ```sh
 graphcool init --copy cj2m5hoko73t901758a052m5q


### PR DESCRIPTION
Clone is confusing here (too close to git clone), it should be copy instead, especially since the article uses copy as well.