### PR TITLE
Changed Routing Link to Relay Modern

### DIFF
--- a/content/tutorials/clients/relay-modern/getting-started.md
+++ b/content/tutorials/clients/relay-modern/getting-started.md
@@ -744,7 +744,7 @@ One thing you'll have to figure out next is how to display that new page in the 
 
 An interesting side-note is that Relay actually started out as a routing framework that eventually also got connected with data loading responsibilities. This was particularly visible in the design of Relay Classic, where [`Relay.Route`](https://facebook.github.io/relay/docs/api-reference-relay-route.html) was a core component. However with Relay Modern, the idea is to move away from having routing as an integral part of Relay and make it more flexible for different routing solutions.
 
-Since we're in the early days of Relay Modern, there's not really much advise or conventions to build upon. The FB team delivers a [few suggestions](https://facebook.github.io/relay/docs/api-reference-relay-route.html) how this can be handled. But it will certainly take some time until best practices and appropriate tools around this topic evolve!
+Since we're in the early days of Relay Modern, there's not really much advise or conventions to build upon. The FB team delivers a [few suggestions](https://facebook.github.io/relay/docs/routing.html) how this can be handled. But it will certainly take some time until best practices and appropriate tools around this topic evolve!
 
 So, to keep it simple in this tutorial, we'll use `react-router` which is a popular routing solution. The first thing you need to do is install the corresponding dependency:
 


### PR DESCRIPTION
The facebook suggestions linked to a Relay Classic Page and not to the Relay Modern Routing solutions.