### PR TITLE
Update project file links

### DIFF
--- a/content/reference/migrations/overview.md
+++ b/content/reference/migrations/overview.md
@@ -14,7 +14,7 @@ related:
 
 # Migrations
 
-Schema migrations covers all changes you can make to your [data schema](!alias-ahwoh2fohj). This includes adding or modifying [types](!alias-ij2choozae), [fields](!alias-teizeit5se) and [relations](!alias-goh5uthoc1). Changes to your schema will be reflected in both the [Schema Editor in the Console](!alias-zezoo7uaph) as well as the [project file](!alias-uhieg2shio) and affect the operations in your [API](!alias-heshoov3ai).
+Schema migrations covers all changes you can make to your [data schema](!alias-ahwoh2fohj). This includes adding or modifying [types](!alias-ij2choozae), [fields](!alias-teizeit5se) and [relations](!alias-goh5uthoc1). Changes to your schema will be reflected in both the [Schema Editor in the Console](!alias-zezoo7uaph) as well as the [project file](!alias-ow2yei7mew) and affect the operations in your [API](!alias-heshoov3ai).
 
 You can either use the [Console](!alias-uh8shohxie) or the [CLI](!alias-kie1quohli) to execute schema migrations, but we'll use the GraphQL schema to describe possible schema migrations in the following sections.
 
@@ -24,4 +24,4 @@ The [Console](!alias-uh8shohxie) provides two ways to update the schema. You can
 
 ## Schema Migrations with the CLI
 
-The [CLI](!alias-kie1quohli) leverages the [project file](!alias-uhieg2shio) and allows you to synchronize schema changes across your local environment and the Console.
+The [CLI](!alias-kie1quohli) leverages the [project file](!alias-ow2yei7mew) and allows you to synchronize schema changes across your local environment and the Console.


### PR DESCRIPTION
I think these are supposed to link to https://github.com/graphcool/content/blob/dev/content/reference/cli/project-file.md

Currently they link to this page https://www.graph.cool/docs/reference/schema/system-artifacts-uhieg2shio/